### PR TITLE
Patch Enbesa Cultural

### DIFF
--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/export/main/asset/assets.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/export/main/asset/assets.xml
@@ -1549,74 +1549,56 @@
 	</Group>
 
 	<!-- #FAMS ENBESAN FLORA INTEGRATION -->
-	<Group Condition="@1660011001">
+	<Group Condition="#Fam_EnbesanFlora">
 		<!-- Second Page at Botanical Garden -->
 		<ModOp Type="replace" GUID="110935,114141,1999000113" Path="/Values/Culture/Sets">
-			<Sets>
-				<Item>
-					<Set>193665</Set>
-				</Item>
-				<Item>
-					<Set>193653</Set>
-				</Item>
-				<Item>
-					<Set>193662</Set>
-				</Item>
-				<Item>
-					<Set>193655</Set>
-				</Item>
-				<Item />
-				<Item>
-					<Set>193660</Set>
-				</Item>
-				<Item>
-					<Set>193657</Set>
-				</Item>
-				<Item>
-					<Set>193658</Set>
-				</Item>
-				<Item>
-					<Set>193670</Set>
-				</Item>
-				<Item>
-					<Set>193672</Set>
-				</Item>
-				<Item />
-				<Item />
-			</Sets>
+		<Sets>
+			<Item>
+			<Set>193665</Set>
+			</Item>
+			<Item>
+			<Set>193653</Set>
+			</Item>
+			<Item>
+			<Set>193662</Set>
+			</Item>
+			<Item>
+			<Set>193655</Set>
+			</Item>
+			<Item />
+			<Item>
+			<Set>193660</Set>
+			</Item>
+			<Item>
+			<Set>193657</Set>
+			</Item>
+			<Item>
+			<Set>193658</Set>
+			</Item>
+			<Item>
+			<Set>193670</Set>
+			</Item>
+			<Item>
+			<Set>193672</Set>
+			</Item>
+			<Item />
+			<Item />
+		</Sets>
 		</ModOp>
 
-		<ModOp Type="add" GUID="110935,114141,1999000113"
-			Path='//Values/Culture/Sets[count(Item)=12]'>
-			<Item>
-				<Set>65488</Set>
-			</Item>
-			<Item>
-				<Set>65488</Set>
-			</Item>
-			<Item>
-				<Set>65488</Set>
-			</Item>
-			<Item>
-				<Set>65488</Set>
-			</Item>
-		</ModOp>
-
-		<ModOp Type="replace" GUID="110935,114141,1999000113"
-			Path='//Values/Culture/Sets/Item[Set/text()="65488"][1]/Set'>
+		<ModOp Type="add" GUID="110935,114141,1999000113" Path='//Values/Culture/Sets'>
+		<Item>
 			<Set>1660011001</Set>
-		</ModOp>
-		<ModOp Type="replace" GUID="110935,114141,1999000113"
-			Path='//Values/Culture/Sets/Item[Set/text()="65488"][1]/Set'>
+		</Item>
+		<Item>
 			<Set>1660011101</Set>
-		</ModOp>
-		<ModOp Type="replace" GUID="110935,114141,1999000113"
-			Path='//Values/Culture/Sets/Item[Set/text()="65488"][1]/Set'>
+		</Item>
+		<Item>
 			<Set>1660011201</Set>
-		</ModOp>
-		<ModOp Type="replace" GUID="110935,114141,1999000113"
-			Path='//Values/Culture/Sets/Item[Set/text()="65488"][1]/Set'>
+		</Item>
+		<Item>
 			<Set>1660011301</Set>
+		</Item>
 		</ModOp>
 
 		<!-- Split Buff Enbesa Plateau into sessions -->

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/export/main/asset/assets.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/export/main/asset/assets.xml
@@ -1121,8 +1121,11 @@
 			</Asset>
 		</ModOp>
 
-		<Group Condition="#Taludas_CoffeeTobaccoEnbesa">
+		<Group Condition="#Taludas_CoffeeTobaccoEnbesa_modio">
 			<ModOp Type="merge" GUID="1999000116" Path="/Values">
+					<Standard>
+						<GUID>1500302096</GUID>
+					</Standard>
 				<ItemEffect>
 					<EffectTargets>
 						<Item>
@@ -1134,11 +1137,46 @@
 					<AddedFertility>1010577</AddedFertility>
 				</FactoryUpgrade>
 			</ModOp>
-			<ModOp Type="add" GUID="1500301931" Path="/Values/ItemEffectTargetPool/EffectTargetGUIDs" Condition="/Values/ItemEffectTargetPool/EffectTargetGUIDs/Item[GUID='1999000102']">
+			<ModOp Type="merge" GUID="193665" Path="/Values/ItemSocketSet/RegionSetBuff">
+				<Africa>
+					<SetBuff>1500302096</SetBuff>
+				</Africa>
+			</ModOp>
+			<ModOp Type="add" GUID="1500301931" Path="/Values/ItemEffectTargetPool/EffectTargetGUIDs" Condition="!/Values/ItemEffectTargetPool/EffectTargetGUIDs/Item[GUID='1999000102']">
 				<Item>
 					<GUID>1999000102</GUID>
 				</Item>
 			</ModOp>
+		</Group>
+
+		<Group Condition="#Taludas_CoffeeTobaccoEnbesa">
+			<Group Condition="!#Taludas_CoffeeTobaccoEnbesa_modio">
+				<ModOp Type="merge" GUID="1999000116" Path="/Values">
+					<Standard>
+						<GUID>1500302096</GUID>
+					</Standard>
+					<ItemEffect>
+						<EffectTargets>
+							<Item>
+								<GUID>1500301931</GUID>
+							</Item>
+						</EffectTargets>
+					</ItemEffect>
+					<FactoryUpgrade>
+						<AddedFertility>1010577</AddedFertility>
+					</FactoryUpgrade>
+				</ModOp>
+				<ModOp Type="merge" GUID="193665" Path="/Values/ItemSocketSet/RegionSetBuff">
+					<Africa>
+						<SetBuff>1500302096</SetBuff>
+					</Africa>
+				</ModOp>
+				<ModOp Type="add" GUID="1500301931" Path="/Values/ItemEffectTargetPool/EffectTargetGUIDs" Condition="!/Values/ItemEffectTargetPool/EffectTargetGUIDs/Item[GUID='1999000102']">
+					<Item>
+						<GUID>1999000102</GUID>
+					</Item>
+				</ModOp>
+			</Group>
 		</Group>
 
 		<ModOp Type="addNextSibling" GUID="22411">
@@ -1215,8 +1253,11 @@
 			</Asset>
 		</ModOp>
 
-		<Group Condition="#Taludas_CoffeeTobaccoEnbesa">
+		<Group Condition="#Taludas_CoffeeTobaccoEnbesa_modio">
 			<ModOp Type="merge" GUID="1999000118" Path="/Values">
+				<Standard>
+					<GUID>1500302097</GUID>
+				</Standard>
 				<ItemEffect>
 					<EffectTargets>
 						<Item>
@@ -1228,11 +1269,46 @@
 					<AddedFertility>120039</AddedFertility>
 				</FactoryUpgrade>
 			</ModOp>
-			<ModOp Type="add" GUID="1500301933" Path="/Values/ItemEffectTargetPool/EffectTargetGUIDs" Condition="/Values/ItemEffectTargetPool/EffectTargetGUIDs/Item[GUID='1999000102']">
+			<ModOp Type="merge" GUID="193672" Path="/Values/ItemSocketSet/RegionSetBuff">
+				<Africa>
+					<SetBuff>1500302097</SetBuff>
+				</Africa>
+			</ModOp>
+			<ModOp Type="add" GUID="1500301933" Path="/Values/ItemEffectTargetPool/EffectTargetGUIDs" Condition="!/Values/ItemEffectTargetPool/EffectTargetGUIDs/Item[GUID='1999000102']">
 				<Item>
 					<GUID>1999000100</GUID>
 				</Item>
 			</ModOp>
+		</Group>
+
+		<Group Condition="#Taludas_CoffeeTobaccoEnbesa">
+			<Group Condition="!#Taludas_CoffeeTobaccoEnbesa_modio">
+				<ModOp Type="merge" GUID="1999000118" Path="/Values">
+					<Standard>
+						<GUID>1500302097</GUID>
+					</Standard>
+					<ItemEffect>
+						<EffectTargets>
+							<Item>
+								<GUID>1500301933</GUID>
+							</Item>
+						</EffectTargets>
+					</ItemEffect>
+					<FactoryUpgrade>
+						<AddedFertility>120039</AddedFertility>
+					</FactoryUpgrade>
+				</ModOp>
+				<ModOp Type="merge" GUID="193672" Path="/Values/ItemSocketSet/RegionSetBuff">
+					<Africa>
+						<SetBuff>1500302097</SetBuff>
+					</Africa>
+				</ModOp>
+				<ModOp Type="add" GUID="1500301933" Path="/Values/ItemEffectTargetPool/EffectTargetGUIDs" Condition="!/Values/ItemEffectTargetPool/EffectTargetGUIDs/Item[GUID='1999000100']">
+					<Item>
+						<GUID>1999000100</GUID>
+					</Item>
+				</ModOp>
+			</Group>
 		</Group>
 
 		<ModOp Type="addNextSibling" GUID="22411">

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/export/main/asset/assets.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/export/main/asset/assets.xml
@@ -63,6 +63,7 @@
 							</English>
 						</LocaText>
 						<LineID>20113</LineID>
+						<TextOverride>1010471</TextOverride>
 					</Text>
 					<Constructable />
 					<Locked />
@@ -281,8 +282,8 @@
 				<Building>1999000111</Building>
 			</Item>
 		</ModOp>
-		<ModOp Type="addNextSibling" GUID="119012"
-			Path="/Values/ConstructionCategory/BuildingList/Item[Building='117859']">
+		<ModOp Type="add" GUID="119015"
+			Path="/Values/ConstructionCategory/BuildingList">
 			<Item>
 				<Building>1999000111</Building>
 			</Item>
@@ -402,6 +403,7 @@
 							</English>
 						</LocaText>
 						<LineID>20112</LineID>
+						<TextOverride>1010470</TextOverride>
 					</Text>
 					<Constructable />
 					<Locked />
@@ -623,8 +625,8 @@
 				<Building>1999000112</Building>
 			</Item>
 		</ModOp>
-		<ModOp Type="addNextSibling" GUID="119012"
-			Path="/Values/ConstructionCategory/BuildingList/Item[Building='117859']">
+		<ModOp Type="add" GUID="119015"
+			Path="/Values/ConstructionCategory/BuildingList">
 			<Item>
 				<Building>1999000112</Building>
 			</Item>
@@ -765,6 +767,7 @@
 							</English>
 						</LocaText>
 						<LineID>33177</LineID>
+						<TextOverride>110935</TextOverride>
 					</Text>
 					<Constructable />
 					<Locked>
@@ -1015,6 +1018,7 @@
 							</English>
 						</LocaText>
 						<LineID>33510</LineID>
+						<TextOverride>193764</TextOverride>
 					</Text>
 					<FactoryUpgrade>
 						<ProductivityUpgrade>
@@ -1027,10 +1031,7 @@
 					<Buff>
 						<PossibleFluffTexts>
 							<Item>
-								<FluffText>22404</FluffText>
-							</Item>
-							<Item>
-								<FluffText>22409</FluffText>
+								<FluffText>1999000115</FluffText>
 							</Item>
 						</PossibleFluffTexts>
 					</Buff>
@@ -1046,30 +1047,15 @@
 			</Asset>
 		</ModOp>
 
-		<ModOp Type="add" GUID="193652,193764" Path="/Values/Buff/PossibleFluffTexts">
-			<Item>
-				<FluffText>1999000115</FluffText>
-			</Item>
-		</ModOp>
-
 		<ModOp Type="addNextSibling" GUID="22409">
 			<Asset>
 				<Template>Text</Template>
 				<Values>
 					<Standard>
 						<GUID>1999000115</GUID>
-						<Name>Hibiscus in Enbesa</Name>
+						<Name>Amazonas_Fluff_Enbesa</Name>
 						<IconFilename>data/ui/2kimages/main/3dicons/goods_africa/icon_hibiscus_farm.png</IconFilename>
 					</Standard>
-					<Text>
-						<LocaText>
-							<English>
-								<Text>Activates Hibiscus fertility if built in Enbesa.</Text>
-								<Status>Exported</Status>
-							</English>
-						</LocaText>
-						<LineID>33290</LineID>
-					</Text>
 				</Values>
 			</Asset>
 		</ModOp>
@@ -1106,6 +1092,7 @@
 							</English>
 						</LocaText>
 						<LineID>33507</LineID>
+						<TextOverride>193664</TextOverride>
 					</Text>
 					<FactoryUpgrade>
 						<ProductivityUpgrade>
@@ -1118,10 +1105,7 @@
 					<Buff>
 						<PossibleFluffTexts>
 							<Item>
-								<FluffText>22405</FluffText>
-							</Item>
-							<Item>
-								<FluffText>22410</FluffText>
+								<FluffText>1999000117</FluffText>
 							</Item>
 						</PossibleFluffTexts>
 					</Buff>
@@ -1137,30 +1121,15 @@
 			</Asset>
 		</ModOp>
 
-		<ModOp Type="add" GUID="193664,193767" Path="/Values/Buff/PossibleFluffTexts">
-			<Item>
-				<FluffText>1999000117</FluffText>
-			</Item>
-		</ModOp>
-
 		<ModOp Type="addNextSibling" GUID="22411">
 			<Asset>
 				<Template>Text</Template>
 				<Values>
 					<Standard>
 						<GUID>1999000117</GUID>
-						<Name>Tabak in Enbesa</Name>
+						<Name>Anden_Fluff_Enbesa</Name>
 						<IconFilename>data/ui/2kimages/main/3dicons/icon_tobacco.png</IconFilename>
 					</Standard>
-					<Text>
-						<LocaText>
-							<English>
-								<Text>Activates Tobacco fertility if built in Enbesa.</Text>
-								<Status>Exported</Status>
-							</English>
-						</LocaText>
-						<LineID>33290</LineID>
-					</Text>
 				</Values>
 			</Asset>
 		</ModOp>
@@ -1197,6 +1166,7 @@
 							</English>
 						</LocaText>
 						<LineID>33507</LineID>
+              			<TextOverride>193671</TextOverride>
 					</Text>
 					<FactoryUpgrade>
 						<ProductivityUpgrade>
@@ -1209,10 +1179,7 @@
 					<Buff>
 						<PossibleFluffTexts>
 							<Item>
-								<FluffText>22406</FluffText>
-							</Item>
-							<Item>
-								<FluffText>22411</FluffText>
+								<FluffText>1999000119</FluffText>
 							</Item>
 						</PossibleFluffTexts>
 					</Buff>
@@ -1228,30 +1195,15 @@
 			</Asset>
 		</ModOp>
 
-		<ModOp Type="add" GUID="193671,193768" Path="/Values/Buff/PossibleFluffTexts">
-			<Item>
-				<FluffText>1999000119</FluffText>
-			</Item>
-		</ModOp>
-
 		<ModOp Type="addNextSibling" GUID="22411">
 			<Asset>
 				<Template>Text</Template>
 				<Values>
 					<Standard>
 						<GUID>1999000119</GUID>
-						<Name>Coffee in Enbesa</Name>
+						<Name>Enchanted_Fluff_Enbesa</Name>
 						<IconFilename>data/ui/2kimages/main/3dicons/icon_coffee_beans.png</IconFilename>
 					</Standard>
-					<Text>
-						<LocaText>
-							<English>
-								<Text>Activates Coffee fertility if built in Enbesa.</Text>
-								<Status>Exported</Status>
-							</English>
-						</LocaText>
-						<LineID>33290</LineID>
-					</Text>
 				</Values>
 			</Asset>
 		</ModOp>
@@ -1288,6 +1240,7 @@
 							</English>
 						</LocaText>
 						<LineID>33507</LineID>
+              			<TextOverride>193765</TextOverride>
 					</Text>
 					<FactoryUpgrade>
 						<ProductivityUpgrade>
@@ -1300,10 +1253,7 @@
 					<Buff>
 						<PossibleFluffTexts>
 							<Item>
-								<FluffText>22407</FluffText>
-							</Item>
-							<Item>
-								<FluffText>22412</FluffText>
+								<FluffText>1999000121</FluffText>
 							</Item>
 						</PossibleFluffTexts>
 					</Buff>
@@ -1319,30 +1269,15 @@
 			</Asset>
 		</ModOp>
 
-		<ModOp Type="add" GUID="193659,193765" Path="/Values/Buff/PossibleFluffTexts">
-			<Item>
-				<FluffText>1999000121</FluffText>
-			</Item>
-		</ModOp>
-
 		<ModOp Type="addNextSibling" GUID="22411">
 			<Asset>
 				<Template>Text</Template>
 				<Values>
 					<Standard>
 						<GUID>1999000121</GUID>
-						<Name>Spices in Enbesa</Name>
+						<Name>Near_East_Fluff_Enbesa</Name>
 						<IconFilename>data/ui/2kimages/main/3dicons/goods_africa/icon_spices.png</IconFilename>
 					</Standard>
-					<Text>
-						<LocaText>
-							<English>
-								<Text>Activates Spices fertility if built in Enbesa.</Text>
-								<Status>Exported</Status>
-							</English>
-						</LocaText>
-						<LineID>33290</LineID>
-					</Text>
 				</Values>
 			</Asset>
 		</ModOp>
@@ -1379,6 +1314,7 @@
 							</English>
 						</LocaText>
 						<LineID>33507</LineID>
+						<TextOverride>193766</TextOverride>
 					</Text>
 					<FactoryUpgrade>
 						<ProductivityUpgrade>
@@ -1391,10 +1327,7 @@
 					<Buff>
 						<PossibleFluffTexts>
 							<Item>
-								<FluffText>22403</FluffText>
-							</Item>
-							<Item>
-								<FluffText>22408</FluffText>
+								<FluffText>1999000123</FluffText>
 							</Item>
 						</PossibleFluffTexts>
 					</Buff>
@@ -1410,30 +1343,15 @@
 			</Asset>
 		</ModOp>
 
-		<ModOp Type="add" GUID="193663,193766" Path="/Values/Buff/PossibleFluffTexts">
-			<Item>
-				<FluffText>1999000123</FluffText>
-			</Item>
-		</ModOp>
-
 		<ModOp Type="addNextSibling" GUID="22411">
 			<Asset>
 				<Template>Text</Template>
 				<Values>
 					<Standard>
 						<GUID>1999000123</GUID>
-						<Name>Bees in Enbesa</Name>
+						<Name>Subalpine_Fluff_Enbesa</Name>
 						<IconFilename>data/ui/2kimages/main/3dicons/goods_africa/icon_beeswax.png</IconFilename>
 					</Standard>
-					<Text>
-						<LocaText>
-							<English>
-								<Text>Activates Bee Abundance if built in Enbesa.</Text>
-								<Status>Exported</Status>
-							</English>
-						</LocaText>
-						<LineID>33290</LineID>
-					</Text>
 				</Values>
 			</Asset>
 		</ModOp>
@@ -1631,6 +1549,7 @@
 							</English>
 						</LocaText>
 						<LineID>1660011004</LineID>
+            			<TextOverride>1660011003</TextOverride>
 					</Text>
 					<FactoryUpgrade>
 						<AdditionalOutput>
@@ -1715,6 +1634,7 @@
 							</English>
 						</LocaText>
 						<LineID>1660011004</LineID>
+            			<TextOverride>1660011203</TextOverride>
 					</Text>
 					<FactoryUpgrade>
 						<AdditionalOutput>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/export/main/asset/assets.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/export/main/asset/assets.xml
@@ -1080,7 +1080,7 @@
 					<ItemEffect>
 						<EffectTargets>
 							<Item>
-								<GUID>1999000102</GUID>
+								<GUID>114450</GUID>
 							</Item>
 						</EffectTargets>
 					</ItemEffect>
@@ -1099,7 +1099,7 @@
 							<Value>25</Value>
 							<Percental>1</Percental>
 						</ProductivityUpgrade>
-						<AddedFertility>1010577</AddedFertility>
+						<AddedFertility>114345</AddedFertility>
 					</FactoryUpgrade>
 					<BuildingUpgrade />
 					<Buff>
@@ -1120,6 +1120,26 @@
 				</Values>
 			</Asset>
 		</ModOp>
+
+		<Group Condition="#Taludas_CoffeeTobaccoEnbesa">
+			<ModOp Type="merge" GUID="1999000116" Path="/Values">
+				<ItemEffect>
+					<EffectTargets>
+						<Item>
+							<GUID>1500301931</GUID>
+						</Item>
+					</EffectTargets>
+				</ItemEffect>
+				<FactoryUpgrade>
+					<AddedFertility>1010577</AddedFertility>
+				</FactoryUpgrade>
+			</ModOp>
+			<ModOp Type="add" GUID="1500301931" Path="/Values/ItemEffectTargetPool/EffectTargetGUIDs" Condition="/Values/ItemEffectTargetPool/EffectTargetGUIDs/Item[GUID='1999000102']">
+				<Item>
+					<GUID>1999000102</GUID>
+				</Item>
+			</ModOp>
+		</Group>
 
 		<ModOp Type="addNextSibling" GUID="22411">
 			<Asset>
@@ -1154,7 +1174,7 @@
 					<ItemEffect>
 						<EffectTargets>
 							<Item>
-								<GUID>1999000100</GUID>
+								<GUID>114451</GUID>
 							</Item>
 						</EffectTargets>
 					</ItemEffect>
@@ -1173,7 +1193,7 @@
 							<Value>25</Value>
 							<Percental>1</Percental>
 						</ProductivityUpgrade>
-						<AddedFertility>120039</AddedFertility>
+						<AddedFertility>114347</AddedFertility>
 					</FactoryUpgrade>
 					<BuildingUpgrade />
 					<Buff>
@@ -1194,6 +1214,26 @@
 				</Values>
 			</Asset>
 		</ModOp>
+
+		<Group Condition="#Taludas_CoffeeTobaccoEnbesa">
+			<ModOp Type="merge" GUID="1999000118" Path="/Values">
+				<ItemEffect>
+					<EffectTargets>
+						<Item>
+							<GUID>1500301933</GUID>
+						</Item>
+					</EffectTargets>
+				</ItemEffect>
+				<FactoryUpgrade>
+					<AddedFertility>120039</AddedFertility>
+				</FactoryUpgrade>
+			</ModOp>
+			<ModOp Type="add" GUID="1500301933" Path="/Values/ItemEffectTargetPool/EffectTargetGUIDs" Condition="/Values/ItemEffectTargetPool/EffectTargetGUIDs/Item[GUID='1999000102']">
+				<Item>
+					<GUID>1999000100</GUID>
+				</Item>
+			</ModOp>
+		</Group>
 
 		<ModOp Type="addNextSibling" GUID="22411">
 			<Asset>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_chinese.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_chinese.xml
@@ -1,94 +1,87 @@
 <ModOps>
-
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000111</GUID>
-      <Text>Museum</Text>
-    </Text>
-  </ModOp>	
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000112</GUID>
-      <Text>Zoo</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000113</GUID>
-      <Text>Botanical Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000114</GUID>
-      <Text>Amazonas Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000115</GUID>
-      <Text>Activates hibiscus fertility if built in Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000116</GUID>
-      <Text>Anden Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000117</GUID>
-      <Text>Activates tobacco fertility if built in Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000118</GUID>
-      <Text>Enchanted Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000119</GUID>
-      <Text>Activates coffee fertility if built in Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000120</GUID>
-      <Text>Near East Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000121</GUID>
-      <Text>Activates spices fertility if built in Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000122</GUID>
-      <Text>Subalpin Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000123</GUID>
-      <Text>Activates bee abundance if built in Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000124</GUID>
-      <Text>Inspiration of the Enbesan Plateau</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000125</GUID>
-      <Text>Bountiful Branches Crafting Techniques</Text>
-    </Text>
-  </ModOp>
-
+  <!-- Amazonas Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000115</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000115']/Text"
+        Content="/TextExport/Texts/Text[GUID='22404']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000115']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000115']/Text"
+        Content="/TextExport/Texts/Text[GUID='22409']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22404' or GUID='22409']/Text">&#xD;&#xA;&#xD;&#xA;Activates hibiscus fertility if built in Enbesa.</ModOp>
+    </Group>
+  <!-- Anden Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000117</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
+        Content="/TextExport/Texts/Text[GUID='22405']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
+        Content="/TextExport/Texts/Text[GUID='22410']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text">&#xD;&#xA;&#xD;&#xA;Activates tobacco fertility if built in Enbesa.</ModOp>
+    </Group>
+  <!-- Enchanted Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000119</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
+        Content="/TextExport/Texts/Text[GUID='22406']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
+        Content="/TextExport/Texts/Text[GUID='22411']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text">&#xD;&#xA;&#xD;&#xA;Activates coffee fertility if built in Enbesa.</ModOp>
+    </Group>
+  <!-- Near East Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000121</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000121']/Text"
+        Content="/TextExport/Texts/Text[GUID='22407']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000121']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000121']/Text"
+        Content="/TextExport/Texts/Text[GUID='22412']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22407' or GUID='22412']/Text">&#xD;&#xA;&#xD;&#xA;Activates spices fertility if built in Enbesa.</ModOp>
+    </Group>
+  <!-- Subalpine Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000123</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text"
+        Content="/TextExport/Texts/Text[GUID='22403']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text"
+        Content="/TextExport/Texts/Text[GUID='22408']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22403' or GUID='22408']/Text">&#xD;&#xA;&#xD;&#xA;Activates bee abundance if built in Enbesa.</ModOp>
+    </Group>
 </ModOps>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_chinese.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_chinese.xml
@@ -31,8 +31,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
         Content="/TextExport/Texts/Text[GUID='22410']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates teff fertility if built in Enbesa.</ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates tobacco fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Activates teff fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Activates tobacco fertility if built in Enbesa.</ModOp>
     </Group>
   <!-- Enchanted Garden in Enbesa -->
     <Group>
@@ -49,8 +49,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
         Content="/TextExport/Texts/Text[GUID='22411']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates indigo fertility if built in Enbesa.</ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates coffee fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Activates indigo fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Activates coffee fertility if built in Enbesa.</ModOp>
     </Group>
   <!-- Near East Garden in Enbesa -->
     <Group>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_chinese.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_chinese.xml
@@ -31,7 +31,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
         Content="/TextExport/Texts/Text[GUID='22410']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text">&#xD;&#xA;&#xD;&#xA;Activates tobacco fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates teff fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates tobacco fertility if built in Enbesa.</ModOp>
     </Group>
   <!-- Enchanted Garden in Enbesa -->
     <Group>
@@ -48,7 +49,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
         Content="/TextExport/Texts/Text[GUID='22411']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text">&#xD;&#xA;&#xD;&#xA;Activates coffee fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates indigo fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates coffee fertility if built in Enbesa.</ModOp>
     </Group>
   <!-- Near East Garden in Enbesa -->
     <Group>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_english.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_english.xml
@@ -1,94 +1,87 @@
 <ModOps>
-
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000111</GUID>
-      <Text>Museum</Text>
-    </Text>
-  </ModOp>	
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000112</GUID>
-      <Text>Zoo</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000113</GUID>
-      <Text>Botanical Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000114</GUID>
-      <Text>Amazonas Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000115</GUID>
-      <Text>Activates hibiscus fertility if built in Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000116</GUID>
-      <Text>Anden Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000117</GUID>
-      <Text>Activates tobacco fertility if built in Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000118</GUID>
-      <Text>Enchanted Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000119</GUID>
-      <Text>Activates coffee fertility if built in Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000120</GUID>
-      <Text>Near East Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000121</GUID>
-      <Text>Activates spices fertility if built in Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000122</GUID>
-      <Text>Subalpin Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000123</GUID>
-      <Text>Activates bee abundance if built in Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000124</GUID>
-      <Text>Inspiration of the Enbesan Plateau</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000125</GUID>
-      <Text>Bountiful Branches Crafting Techniques</Text>
-    </Text>
-  </ModOp>
-
+  <!-- Amazonas Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000115</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000115']/Text"
+        Content="/TextExport/Texts/Text[GUID='22404']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000115']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000115']/Text"
+        Content="/TextExport/Texts/Text[GUID='22409']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22404' or GUID='22409']/Text">&#xD;&#xA;&#xD;&#xA;Activates hibiscus fertility if built in Enbesa.</ModOp>
+    </Group>
+  <!-- Anden Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000117</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
+        Content="/TextExport/Texts/Text[GUID='22405']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
+        Content="/TextExport/Texts/Text[GUID='22410']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text">&#xD;&#xA;&#xD;&#xA;Activates tobacco fertility if built in Enbesa.</ModOp>
+    </Group>
+  <!-- Enchanted Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000119</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
+        Content="/TextExport/Texts/Text[GUID='22406']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
+        Content="/TextExport/Texts/Text[GUID='22411']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text">&#xD;&#xA;&#xD;&#xA;Activates coffee fertility if built in Enbesa.</ModOp>
+    </Group>
+  <!-- Near East Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000121</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000121']/Text"
+        Content="/TextExport/Texts/Text[GUID='22407']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000121']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000121']/Text"
+        Content="/TextExport/Texts/Text[GUID='22412']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22407' or GUID='22412']/Text">&#xD;&#xA;&#xD;&#xA;Activates spices fertility if built in Enbesa.</ModOp>
+    </Group>
+  <!-- Subalpine Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000123</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text"
+        Content="/TextExport/Texts/Text[GUID='22403']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text"
+        Content="/TextExport/Texts/Text[GUID='22408']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22403' or GUID='22408']/Text">&#xD;&#xA;&#xD;&#xA;Activates bee abundance if built in Enbesa.</ModOp>
+    </Group>
 </ModOps>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_english.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_english.xml
@@ -31,8 +31,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
         Content="/TextExport/Texts/Text[GUID='22410']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates teff fertility if built in Enbesa.</ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates tobacco fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Activates teff fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Activates tobacco fertility if built in Enbesa.</ModOp>
     </Group>
   <!-- Enchanted Garden in Enbesa -->
     <Group>
@@ -49,8 +49,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
         Content="/TextExport/Texts/Text[GUID='22411']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates indigo fertility if built in Enbesa.</ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates coffee fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Activates indigo fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Activates coffee fertility if built in Enbesa.</ModOp>
     </Group>
   <!-- Near East Garden in Enbesa -->
     <Group>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_english.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_english.xml
@@ -31,7 +31,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
         Content="/TextExport/Texts/Text[GUID='22410']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text">&#xD;&#xA;&#xD;&#xA;Activates tobacco fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates teff fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates tobacco fertility if built in Enbesa.</ModOp>
     </Group>
   <!-- Enchanted Garden in Enbesa -->
     <Group>
@@ -48,7 +49,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
         Content="/TextExport/Texts/Text[GUID='22411']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text">&#xD;&#xA;&#xD;&#xA;Activates coffee fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates indigo fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates coffee fertility if built in Enbesa.</ModOp>
     </Group>
   <!-- Near East Garden in Enbesa -->
     <Group>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_french.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_french.xml
@@ -31,8 +31,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
         Content="/TextExport/Texts/Text[GUID='22410']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Active la fertilité pour le teff si construit à Enbesa.</ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Active la fertilité pour le tabac si construit à Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Active la fertilité pour le teff si construit à Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Active la fertilité pour le tabac si construit à Enbesa.</ModOp>
     </Group>
   <!-- Enchanted Garden in Enbesa -->
     <Group>
@@ -49,8 +49,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
         Content="/TextExport/Texts/Text[GUID='22411']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Active la fertilité pour le indigo si construit à Enbesa.</ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Active la fertilité pour le café si construit à Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Active la fertilité pour le indigo si construit à Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Active la fertilité pour le café si construit à Enbesa.</ModOp>
     </Group>
   <!-- Near East Garden in Enbesa -->
     <Group>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_french.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_french.xml
@@ -1,94 +1,87 @@
 <ModOps>
-
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000111</GUID>
-      <Text>Musée</Text>
-    </Text>
-  </ModOp>	
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000112</GUID>
-      <Text>Zoo</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000113</GUID>
-      <Text>Jardin Botanique</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000114</GUID>
-      <Text>Jardin Amazonien</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000115</GUID>
-      <Text>Active la fertilité pour l'hibiscus si construit à Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000116</GUID>
-      <Text>Jardin Andin</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000117</GUID>
-      <Text>Active la fertilité pour le tabac si construit à Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000118</GUID>
-      <Text>Jardin Enchanté</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000119</GUID>
-      <Text>Active la fertilité pour le café si construit à Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000120</GUID>
-      <Text>Jardin Oriental</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000121</GUID>
-      <Text>Active la fertilité pour les épices si construit à Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000122</GUID>
-      <Text>Jardin Subalpin</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000123</GUID>
-      <Text>Active l'abondance d'abeilles si construit à Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000124</GUID>
-      <Text>Inspiration Enbesane</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000125</GUID>
-      <Text>Techniques d'artisanat fin sur les branches infinies</Text>
-    </Text>
-  </ModOp>
-
+  <!-- Amazonas Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000115</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000115']/Text"
+        Content="/TextExport/Texts/Text[GUID='22404']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000115']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000115']/Text"
+        Content="/TextExport/Texts/Text[GUID='22409']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22404' or GUID='22409']/Text">&#xD;&#xA;&#xD;&#xA;Active la fertilité pour l'hibiscus si construit à Enbesa.</ModOp>
+    </Group>
+  <!-- Anden Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000117</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
+        Content="/TextExport/Texts/Text[GUID='22405']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
+        Content="/TextExport/Texts/Text[GUID='22410']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text">&#xD;&#xA;&#xD;&#xA;Active la fertilité pour le tabac si construit à Enbesa.</ModOp>
+    </Group>
+  <!-- Enchanted Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000119</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
+        Content="/TextExport/Texts/Text[GUID='22406']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
+        Content="/TextExport/Texts/Text[GUID='22411']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text">&#xD;&#xA;&#xD;&#xA;Active la fertilité pour le café si construit à Enbesa.</ModOp>
+    </Group>
+  <!-- Near East Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000121</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000121']/Text"
+        Content="/TextExport/Texts/Text[GUID='22407']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000121']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000121']/Text"
+        Content="/TextExport/Texts/Text[GUID='22412']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22407' or GUID='22412']/Text">&#xD;&#xA;&#xD;&#xA;Active la fertilité pour les épices si construit à Enbesa.</ModOp>
+    </Group>
+  <!-- Subalpine Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000123</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text"
+        Content="/TextExport/Texts/Text[GUID='22403']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text"
+        Content="/TextExport/Texts/Text[GUID='22408']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22403' or GUID='22408']/Text">&#xD;&#xA;&#xD;&#xA;Active l'abondance d'abeilles si construit à Enbesa.</ModOp>
+    </Group>
 </ModOps>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_french.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_french.xml
@@ -31,7 +31,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
         Content="/TextExport/Texts/Text[GUID='22410']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text">&#xD;&#xA;&#xD;&#xA;Active la fertilité pour le tabac si construit à Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Active la fertilité pour le teff si construit à Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Active la fertilité pour le tabac si construit à Enbesa.</ModOp>
     </Group>
   <!-- Enchanted Garden in Enbesa -->
     <Group>
@@ -48,7 +49,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
         Content="/TextExport/Texts/Text[GUID='22411']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text">&#xD;&#xA;&#xD;&#xA;Active la fertilité pour le café si construit à Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Active la fertilité pour le indigo si construit à Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Active la fertilité pour le café si construit à Enbesa.</ModOp>
     </Group>
   <!-- Near East Garden in Enbesa -->
     <Group>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_german.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_german.xml
@@ -31,7 +31,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
         Content="/TextExport/Texts/Text[GUID='22410']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text">&#xD;&#xA;&#xD;&#xA;Aktiviert Tabak-Fruchtbarkeit, sofern in Enbesa errichtet.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Aktiviert Teff-Fruchtbarkeit, sofern in Enbesa errichtet.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Aktiviert Tabak-Fruchtbarkeit, sofern in Enbesa errichtet.</ModOp>
     </Group>
   <!-- Enchanted Garden in Enbesa -->
     <Group>
@@ -48,7 +49,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
         Content="/TextExport/Texts/Text[GUID='22411']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text">&#xD;&#xA;&#xD;&#xA;Aktiviert Kaffee-Fruchtbarkeit, sofern in Enbesa errichtet.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Aktiviert Indigo-Fruchtbarkeit, sofern in Enbesa errichtet.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Aktiviert Kaffee-Fruchtbarkeit, sofern in Enbesa errichtet.</ModOp>
     </Group>
   <!-- Near East Garden in Enbesa -->
     <Group>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_german.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_german.xml
@@ -1,93 +1,87 @@
 <ModOps>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000111</GUID>
-      <Text>Museum</Text>
-    </Text>
-  </ModOp>	
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000112</GUID>
-      <Text>Zoo</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000113</GUID>
-      <Text>Botanischer Garten</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000114</GUID>
-      <Text>Amazonas-Garten</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000115</GUID>
-      <Text>Aktiviert Hibiskus-Fruchtbarkeit, sofern in Enbesa errichtet.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000116</GUID>
-      <Text>Anden-Garten</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000117</GUID>
-      <Text>Aktiviert Tabak-Fruchtbarkeit, sofern in Enbesa errichtet.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000118</GUID>
-      <Text>Verwunschener Garten</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000119</GUID>
-      <Text>Aktiviert Kaffee-Fruchtbarkeit, sofern in Enbesa errichtet.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000120</GUID>
-      <Text>Nahost-​Garten</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000121</GUID>
-      <Text>Aktiviert Gewürz-Fruchtbarkeit, sofern in Enbesa errichtet.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000122</GUID>
-      <Text>Subalpin-​Garten</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000123</GUID>
-      <Text>Aktiviert Bienen im Überfluss, sofern in Enbesa errichtet.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000124</GUID>
-      <Text>Inspiration der Enbesanischen Hochebene</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000125</GUID>
-      <Text>Üppige Zweige Handwerkstechniken</Text>
-    </Text>
-  </ModOp>
-
+  <!-- Amazonas Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000115</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000115']/Text"
+        Content="/TextExport/Texts/Text[GUID='22404']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000115']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000115']/Text"
+        Content="/TextExport/Texts/Text[GUID='22409']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22404' or GUID='22409']/Text">&#xD;&#xA;&#xD;&#xA;Aktiviert Hibiskus-Fruchtbarkeit, sofern in Enbesa errichtet.</ModOp>
+    </Group>
+  <!-- Anden Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000117</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
+        Content="/TextExport/Texts/Text[GUID='22405']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
+        Content="/TextExport/Texts/Text[GUID='22410']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text">&#xD;&#xA;&#xD;&#xA;Aktiviert Tabak-Fruchtbarkeit, sofern in Enbesa errichtet.</ModOp>
+    </Group>
+  <!-- Enchanted Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000119</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
+        Content="/TextExport/Texts/Text[GUID='22406']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
+        Content="/TextExport/Texts/Text[GUID='22411']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text">&#xD;&#xA;&#xD;&#xA;Aktiviert Kaffee-Fruchtbarkeit, sofern in Enbesa errichtet.</ModOp>
+    </Group>
+  <!-- Near East Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000121</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000121']/Text"
+        Content="/TextExport/Texts/Text[GUID='22407']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000121']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000121']/Text"
+        Content="/TextExport/Texts/Text[GUID='22412']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22407' or GUID='22412']/Text">&#xD;&#xA;&#xD;&#xA;Aktiviert Gewürz-Fruchtbarkeit, sofern in Enbesa errichtet.</ModOp>
+    </Group>
+  <!-- Subalpine Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000123</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text"
+        Content="/TextExport/Texts/Text[GUID='22403']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text"
+        Content="/TextExport/Texts/Text[GUID='22408']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22403' or GUID='22408']/Text">&#xD;&#xA;&#xD;&#xA;Aktiviert Bienen im Überfluss, sofern in Enbesa errichtet..</ModOp>
+    </Group>
 </ModOps>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_german.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_german.xml
@@ -31,8 +31,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
         Content="/TextExport/Texts/Text[GUID='22410']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Aktiviert Teff-Fruchtbarkeit, sofern in Enbesa errichtet.</ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Aktiviert Tabak-Fruchtbarkeit, sofern in Enbesa errichtet.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Aktiviert Teff-Fruchtbarkeit, sofern in Enbesa errichtet.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Aktiviert Tabak-Fruchtbarkeit, sofern in Enbesa errichtet.</ModOp>
     </Group>
   <!-- Enchanted Garden in Enbesa -->
     <Group>
@@ -49,8 +49,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
         Content="/TextExport/Texts/Text[GUID='22411']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Aktiviert Indigo-Fruchtbarkeit, sofern in Enbesa errichtet.</ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Aktiviert Kaffee-Fruchtbarkeit, sofern in Enbesa errichtet.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Aktiviert Indigo-Fruchtbarkeit, sofern in Enbesa errichtet.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Aktiviert Kaffee-Fruchtbarkeit, sofern in Enbesa errichtet.</ModOp>
     </Group>
   <!-- Near East Garden in Enbesa -->
     <Group>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_german.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_german.xml
@@ -82,6 +82,6 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text"
         Content="/TextExport/Texts/Text[GUID='22408']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22403' or GUID='22408']/Text">&#xD;&#xA;&#xD;&#xA;Aktiviert Bienen im Überfluss, sofern in Enbesa errichtet..</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22403' or GUID='22408']/Text">&#xD;&#xA;&#xD;&#xA;Aktiviert Bienen im Überfluss, sofern in Enbesa errichtet.</ModOp>
     </Group>
 </ModOps>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_italian.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_italian.xml
@@ -1,94 +1,87 @@
 <ModOps>
-
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000111</GUID>
-      <Text>Museum</Text>
-    </Text>
-  </ModOp>	
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000112</GUID>
-      <Text>Zoo</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000113</GUID>
-      <Text>Botanical Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000114</GUID>
-      <Text>Amazonas Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000115</GUID>
-      <Text>Activates hibiscus fertility if built in Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000116</GUID>
-      <Text>Anden Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000117</GUID>
-      <Text>Activates tobacco fertility if built in Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000118</GUID>
-      <Text>Enchanted Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000119</GUID>
-      <Text>Activates coffee fertility if built in Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000120</GUID>
-      <Text>Near East Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000121</GUID>
-      <Text>Activates spices fertility if built in Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000122</GUID>
-      <Text>Subalpin Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000123</GUID>
-      <Text>Activates bee abundance if built in Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000124</GUID>
-      <Text>Inspiration of the Enbesan Plateau</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000125</GUID>
-      <Text>Bountiful Branches Crafting Techniques</Text>
-    </Text>
-  </ModOp>
-
+  <!-- Amazonas Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000115</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000115']/Text"
+        Content="/TextExport/Texts/Text[GUID='22404']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000115']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000115']/Text"
+        Content="/TextExport/Texts/Text[GUID='22409']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22404' or GUID='22409']/Text">&#xD;&#xA;&#xD;&#xA;Activates hibiscus fertility if built in Enbesa.</ModOp>
+    </Group>
+  <!-- Anden Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000117</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
+        Content="/TextExport/Texts/Text[GUID='22405']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
+        Content="/TextExport/Texts/Text[GUID='22410']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text">&#xD;&#xA;&#xD;&#xA;Activates tobacco fertility if built in Enbesa.</ModOp>
+    </Group>
+  <!-- Enchanted Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000119</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
+        Content="/TextExport/Texts/Text[GUID='22406']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
+        Content="/TextExport/Texts/Text[GUID='22411']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text">&#xD;&#xA;&#xD;&#xA;Activates coffee fertility if built in Enbesa.</ModOp>
+    </Group>
+  <!-- Near East Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000121</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000121']/Text"
+        Content="/TextExport/Texts/Text[GUID='22407']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000121']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000121']/Text"
+        Content="/TextExport/Texts/Text[GUID='22412']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22407' or GUID='22412']/Text">&#xD;&#xA;&#xD;&#xA;Activates spices fertility if built in Enbesa.</ModOp>
+    </Group>
+  <!-- Subalpine Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000123</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text"
+        Content="/TextExport/Texts/Text[GUID='22403']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text"
+        Content="/TextExport/Texts/Text[GUID='22408']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22403' or GUID='22408']/Text">&#xD;&#xA;&#xD;&#xA;Activates bee abundance if built in Enbesa.</ModOp>
+    </Group>
 </ModOps>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_italian.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_italian.xml
@@ -31,8 +31,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
         Content="/TextExport/Texts/Text[GUID='22410']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates teff fertility if built in Enbesa.</ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates tobacco fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Activates teff fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Activates tobacco fertility if built in Enbesa.</ModOp>
     </Group>
   <!-- Enchanted Garden in Enbesa -->
     <Group>
@@ -49,8 +49,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
         Content="/TextExport/Texts/Text[GUID='22411']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates indigo fertility if built in Enbesa.</ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates coffee fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Activates indigo fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Activates coffee fertility if built in Enbesa.</ModOp>
     </Group>
   <!-- Near East Garden in Enbesa -->
     <Group>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_italian.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_italian.xml
@@ -31,7 +31,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
         Content="/TextExport/Texts/Text[GUID='22410']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text">&#xD;&#xA;&#xD;&#xA;Activates tobacco fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates teff fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates tobacco fertility if built in Enbesa.</ModOp>
     </Group>
   <!-- Enchanted Garden in Enbesa -->
     <Group>
@@ -48,7 +49,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
         Content="/TextExport/Texts/Text[GUID='22411']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text">&#xD;&#xA;&#xD;&#xA;Activates coffee fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates indigo fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates coffee fertility if built in Enbesa.</ModOp>
     </Group>
   <!-- Near East Garden in Enbesa -->
     <Group>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_japanese.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_japanese.xml
@@ -1,94 +1,87 @@
 <ModOps>
-
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000111</GUID>
-      <Text>Museum</Text>
-    </Text>
-  </ModOp>	
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000112</GUID>
-      <Text>Zoo</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000113</GUID>
-      <Text>Botanical Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000114</GUID>
-      <Text>Amazonas Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000115</GUID>
-      <Text>Activates hibiscus fertility if built in Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000116</GUID>
-      <Text>Anden Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000117</GUID>
-      <Text>Activates tobacco fertility if built in Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000118</GUID>
-      <Text>Enchanted Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000119</GUID>
-      <Text>Activates coffee fertility if built in Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000120</GUID>
-      <Text>Near East Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000121</GUID>
-      <Text>Activates spices fertility if built in Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000122</GUID>
-      <Text>Subalpin Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000123</GUID>
-      <Text>Activates bee abundance if built in Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000124</GUID>
-      <Text>Inspiration of the Enbesan Plateau</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000125</GUID>
-      <Text>Bountiful Branches Crafting Techniques</Text>
-    </Text>
-  </ModOp>
-
+  <!-- Amazonas Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000115</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000115']/Text"
+        Content="/TextExport/Texts/Text[GUID='22404']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000115']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000115']/Text"
+        Content="/TextExport/Texts/Text[GUID='22409']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22404' or GUID='22409']/Text">&#xD;&#xA;&#xD;&#xA;Activates hibiscus fertility if built in Enbesa.</ModOp>
+    </Group>
+  <!-- Anden Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000117</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
+        Content="/TextExport/Texts/Text[GUID='22405']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
+        Content="/TextExport/Texts/Text[GUID='22410']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text">&#xD;&#xA;&#xD;&#xA;Activates tobacco fertility if built in Enbesa.</ModOp>
+    </Group>
+  <!-- Enchanted Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000119</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
+        Content="/TextExport/Texts/Text[GUID='22406']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
+        Content="/TextExport/Texts/Text[GUID='22411']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text">&#xD;&#xA;&#xD;&#xA;Activates coffee fertility if built in Enbesa.</ModOp>
+    </Group>
+  <!-- Near East Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000121</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000121']/Text"
+        Content="/TextExport/Texts/Text[GUID='22407']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000121']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000121']/Text"
+        Content="/TextExport/Texts/Text[GUID='22412']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22407' or GUID='22412']/Text">&#xD;&#xA;&#xD;&#xA;Activates spices fertility if built in Enbesa.</ModOp>
+    </Group>
+  <!-- Subalpine Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000123</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text"
+        Content="/TextExport/Texts/Text[GUID='22403']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text"
+        Content="/TextExport/Texts/Text[GUID='22408']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22403' or GUID='22408']/Text">&#xD;&#xA;&#xD;&#xA;Activates bee abundance if built in Enbesa.</ModOp>
+    </Group>
 </ModOps>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_japanese.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_japanese.xml
@@ -31,8 +31,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
         Content="/TextExport/Texts/Text[GUID='22410']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates teff fertility if built in Enbesa.</ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates tobacco fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Activates teff fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Activates tobacco fertility if built in Enbesa.</ModOp>
     </Group>
   <!-- Enchanted Garden in Enbesa -->
     <Group>
@@ -49,8 +49,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
         Content="/TextExport/Texts/Text[GUID='22411']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates indigo fertility if built in Enbesa.</ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates coffee fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Activates indigo fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Activates coffee fertility if built in Enbesa.</ModOp>
     </Group>
   <!-- Near East Garden in Enbesa -->
     <Group>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_japanese.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_japanese.xml
@@ -31,7 +31,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
         Content="/TextExport/Texts/Text[GUID='22410']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text">&#xD;&#xA;&#xD;&#xA;Activates tobacco fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates teff fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates tobacco fertility if built in Enbesa.</ModOp>
     </Group>
   <!-- Enchanted Garden in Enbesa -->
     <Group>
@@ -48,7 +49,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
         Content="/TextExport/Texts/Text[GUID='22411']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text">&#xD;&#xA;&#xD;&#xA;Activates coffee fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates indigo fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates coffee fertility if built in Enbesa.</ModOp>
     </Group>
   <!-- Near East Garden in Enbesa -->
     <Group>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_korean.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_korean.xml
@@ -14,7 +14,7 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000115']/Text"
         Content="/TextExport/Texts/Text[GUID='22409']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22404' or GUID='22409']/Text">&#xD;&#xA;&#xD;&#xA;Zapewnia żyzność hibiskusa, jeśli jest zbudowany w Enbesie.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22404' or GUID='22409']/Text">&#xD;&#xA;&#xD;&#xA;이 엔베사 섬에서 히비스커스 토착 자원을 활성화합니다.</ModOp>
     </Group>
   <!-- Anden Garden in Enbesa -->
     <Group>
@@ -31,7 +31,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
         Content="/TextExport/Texts/Text[GUID='22410']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text">&#xD;&#xA;&#xD;&#xA;Zapewnia żyzność tytoniu, jeśli jest zbudowany w Enbesie.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;이 엔베사 섬에서 테프 건초 토착 자원을 활성화합니다.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;이 엔베사 섬에서 담배 토착 자원을 활성화합니다.</ModOp>
     </Group>
   <!-- Enchanted Garden in Enbesa -->
     <Group>
@@ -48,7 +49,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
         Content="/TextExport/Texts/Text[GUID='22411']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text">&#xD;&#xA;&#xD;&#xA;Zapewnia żyzność kawy, jeśli jest zbudowany w Enbesie.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;이 엔베사 섬에서 인디고 토착 자원을 활성화합니다.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;이 엔베사 섬에서 커피 토착 자원을 활성화합니다.</ModOp>
     </Group>
   <!-- Near East Garden in Enbesa -->
     <Group>
@@ -65,7 +67,7 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000121']/Text"
         Content="/TextExport/Texts/Text[GUID='22412']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22407' or GUID='22412']/Text">&#xD;&#xA;&#xD;&#xA;Zapewnia żyzność przyprawy, jeśli jest zbudowany w Enbesie.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22407' or GUID='22412']/Text">&#xD;&#xA;&#xD;&#xA;이 엔베사 섬에서 향신료 토착 자원을 활성화합니다.</ModOp>
     </Group>
   <!-- Subalpine Garden in Enbesa -->
     <Group>
@@ -82,6 +84,6 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text"
         Content="/TextExport/Texts/Text[GUID='22408']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22403' or GUID='22408']/Text">&#xD;&#xA;&#xD;&#xA;Zapewnia obfitość pszczół, jeśli jest zbudowany w Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22403' or GUID='22408']/Text">&#xD;&#xA;&#xD;&#xA;이 엔베사 섬에서 벌 토착 자원을 활성화합니다.</ModOp>
     </Group>
 </ModOps>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_korean.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_korean.xml
@@ -31,8 +31,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
         Content="/TextExport/Texts/Text[GUID='22410']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;이 엔베사 섬에서 테프 건초 토착 자원을 활성화합니다.</ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;이 엔베사 섬에서 담배 토착 자원을 활성화합니다.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;이 엔베사 섬에서 테프 건초 토착 자원을 활성화합니다.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;이 엔베사 섬에서 담배 토착 자원을 활성화합니다.</ModOp>
     </Group>
   <!-- Enchanted Garden in Enbesa -->
     <Group>
@@ -49,8 +49,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
         Content="/TextExport/Texts/Text[GUID='22411']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;이 엔베사 섬에서 인디고 토착 자원을 활성화합니다.</ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;이 엔베사 섬에서 커피 토착 자원을 활성화합니다.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;이 엔베사 섬에서 인디고 토착 자원을 활성화합니다.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;이 엔베사 섬에서 커피 토착 자원을 활성화합니다.</ModOp>
     </Group>
   <!-- Near East Garden in Enbesa -->
     <Group>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_korean.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_korean.xml
@@ -1,94 +1,87 @@
 <ModOps>
-
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000111</GUID>
-      <Text>박물관</Text>
-    </Text>
-  </ModOp>	
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000112</GUID>
-      <Text>동물원</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000113</GUID>
-      <Text>식물원</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000114</GUID>
-      <Text>아마조나스 정원</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000115</GUID>
-      <Text>이 엔베사 섬에서 히비스커스 토착 자원을 활성화합니다.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000116</GUID>
-      <Text>안데스 정원</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000117</GUID>
-      <Text>이 엔베사 섬에서 담배 토착 자원을 활성화합니다.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000118</GUID>
-      <Text>마법 정원</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000119</GUID>
-      <Text>이 엔베사 섬에서 커피 토착 자원을 활성화합니다.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000120</GUID>
-      <Text>동방 정원</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000121</GUID>
-      <Text>이 엔베사 섬에서 향신료 토착 자원을 활성화합니다.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000122</GUID>
-      <Text>알프스 산록 정원</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000123</GUID>
-      <Text>이 엔베사 섬에서 벌 토착 자원을 활성화합니다.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000124</GUID>
-      <Text>엔베사 고원의 영감</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000125</GUID>
-      <Text>풍부한 가지 제작 기법</Text>
-    </Text>
-  </ModOp>
-
+  <!-- Amazonas Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000115</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000115']/Text"
+        Content="/TextExport/Texts/Text[GUID='22404']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000115']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000115']/Text"
+        Content="/TextExport/Texts/Text[GUID='22409']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22404' or GUID='22409']/Text">&#xD;&#xA;&#xD;&#xA;Zapewnia żyzność hibiskusa, jeśli jest zbudowany w Enbesie.</ModOp>
+    </Group>
+  <!-- Anden Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000117</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
+        Content="/TextExport/Texts/Text[GUID='22405']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
+        Content="/TextExport/Texts/Text[GUID='22410']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text">&#xD;&#xA;&#xD;&#xA;Zapewnia żyzność tytoniu, jeśli jest zbudowany w Enbesie.</ModOp>
+    </Group>
+  <!-- Enchanted Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000119</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
+        Content="/TextExport/Texts/Text[GUID='22406']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
+        Content="/TextExport/Texts/Text[GUID='22411']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text">&#xD;&#xA;&#xD;&#xA;Zapewnia żyzność kawy, jeśli jest zbudowany w Enbesie.</ModOp>
+    </Group>
+  <!-- Near East Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000121</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000121']/Text"
+        Content="/TextExport/Texts/Text[GUID='22407']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000121']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000121']/Text"
+        Content="/TextExport/Texts/Text[GUID='22412']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22407' or GUID='22412']/Text">&#xD;&#xA;&#xD;&#xA;Zapewnia żyzność przyprawy, jeśli jest zbudowany w Enbesie.</ModOp>
+    </Group>
+  <!-- Subalpine Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000123</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text"
+        Content="/TextExport/Texts/Text[GUID='22403']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text"
+        Content="/TextExport/Texts/Text[GUID='22408']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22403' or GUID='22408']/Text">&#xD;&#xA;&#xD;&#xA;Zapewnia obfitość pszczół, jeśli jest zbudowany w Enbesa.</ModOp>
+    </Group>
 </ModOps>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_polish.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_polish.xml
@@ -1,94 +1,87 @@
 <ModOps>
-
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000111</GUID>
-      <Text>Muzeum</Text>
-    </Text>
-  </ModOp>	
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000112</GUID>
-      <Text>Zoo</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000113</GUID>
-      <Text>Ogród botaniczny</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000114</GUID>
-      <Text>Ogród Amazoński</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000115</GUID>
-      <Text>Zapewnia żyzność hibiskusa, jeśli jest zbudowany w Enbesie.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000116</GUID>
-      <Text>Ogród Andyjski</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000117</GUID>
-      <Text>Zapewnia żyzność tytoniu, jeśli jest zbudowany w Enbesie.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000118</GUID>
-      <Text>Zaczarowany Ogród</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000119</GUID>
-      <Text>Zapewnia żyzność kawy, jeśli jest zbudowany w Enbesie.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000120</GUID>
-      <Text>Ogród Bliskowschodni</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000121</GUID>
-      <Text>Zapewnia żyzność przyprawy, jeśli jest zbudowany w Enbesie.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000122</GUID>
-      <Text>Ogród Subalpejski</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000123</GUID>
-      <Text>Zapewnia obfitość pszczół, jeśli jest zbudowany w Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000124</GUID>
-      <Text>Inspiracja Płaskowyżu Enbesańskiego</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000125</GUID>
-      <Text>Rzemieślnicza technika Chojnych Gałęzi</Text>
-    </Text>
-  </ModOp>
-
+  <!-- Amazonas Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000115</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000115']/Text"
+        Content="/TextExport/Texts/Text[GUID='22404']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000115']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000115']/Text"
+        Content="/TextExport/Texts/Text[GUID='22409']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22404' or GUID='22409']/Text">&#xD;&#xA;&#xD;&#xA;Zapewnia żyzność hibiskusa, jeśli jest zbudowany w Enbesie.</ModOp>
+    </Group>
+  <!-- Anden Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000117</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
+        Content="/TextExport/Texts/Text[GUID='22405']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
+        Content="/TextExport/Texts/Text[GUID='22410']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text">&#xD;&#xA;&#xD;&#xA;Zapewnia żyzność tytoniu, jeśli jest zbudowany w Enbesie.</ModOp>
+    </Group>
+  <!-- Enchanted Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000119</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
+        Content="/TextExport/Texts/Text[GUID='22406']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
+        Content="/TextExport/Texts/Text[GUID='22411']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text">&#xD;&#xA;&#xD;&#xA;Zapewnia żyzność kawy, jeśli jest zbudowany w Enbesie.</ModOp>
+    </Group>
+  <!-- Near East Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000121</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000121']/Text"
+        Content="/TextExport/Texts/Text[GUID='22407']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000121']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000121']/Text"
+        Content="/TextExport/Texts/Text[GUID='22412']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22407' or GUID='22412']/Text">&#xD;&#xA;&#xD;&#xA;Zapewnia żyzność przyprawy, jeśli jest zbudowany w Enbesie.</ModOp>
+    </Group>
+  <!-- Subalpine Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000123</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text"
+        Content="/TextExport/Texts/Text[GUID='22403']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text"
+        Content="/TextExport/Texts/Text[GUID='22408']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22403' or GUID='22408']/Text">&#xD;&#xA;&#xD;&#xA;Zapewnia obfitość pszczół, jeśli jest zbudowany w Enbesa.</ModOp>
+    </Group>
 </ModOps>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_polish.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_polish.xml
@@ -31,7 +31,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
         Content="/TextExport/Texts/Text[GUID='22410']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text">&#xD;&#xA;&#xD;&#xA;Zapewnia żyzność tytoniu, jeśli jest zbudowany w Enbesie.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Zapewnia żyzność trawa teff, jeśli jest zbudowany w Enbesie.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Zapewnia żyzność tytoniu, jeśli jest zbudowany w Enbesie.</ModOp>
     </Group>
   <!-- Enchanted Garden in Enbesa -->
     <Group>
@@ -48,7 +49,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
         Content="/TextExport/Texts/Text[GUID='22411']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text">&#xD;&#xA;&#xD;&#xA;Zapewnia żyzność kawy, jeśli jest zbudowany w Enbesie.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Zapewnia żyzność indygo, jeśli jest zbudowany w Enbesie.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Zapewnia żyzność kawy, jeśli jest zbudowany w Enbesie.</ModOp>
     </Group>
   <!-- Near East Garden in Enbesa -->
     <Group>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_polish.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_polish.xml
@@ -31,8 +31,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
         Content="/TextExport/Texts/Text[GUID='22410']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Zapewnia żyzność trawa teff, jeśli jest zbudowany w Enbesie.</ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Zapewnia żyzność tytoniu, jeśli jest zbudowany w Enbesie.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Zapewnia żyzność trawa teff, jeśli jest zbudowany w Enbesie.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Zapewnia żyzność tytoniu, jeśli jest zbudowany w Enbesie.</ModOp>
     </Group>
   <!-- Enchanted Garden in Enbesa -->
     <Group>
@@ -49,8 +49,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
         Content="/TextExport/Texts/Text[GUID='22411']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Zapewnia żyzność indygo, jeśli jest zbudowany w Enbesie.</ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Zapewnia żyzność kawy, jeśli jest zbudowany w Enbesie.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Zapewnia żyzność indygo, jeśli jest zbudowany w Enbesie.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Zapewnia żyzność kawy, jeśli jest zbudowany w Enbesie.</ModOp>
     </Group>
   <!-- Near East Garden in Enbesa -->
     <Group>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_russian.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_russian.xml
@@ -31,8 +31,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
         Content="/TextExport/Texts/Text[GUID='22410']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Создаёт плодородие для тефа, при нахождении в Энбесе.</ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Создаёт плодородие для табака, при нахождении в Энбесе.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Создаёт плодородие для тефа, при нахождении в Энбесе.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Создаёт плодородие для табака, при нахождении в Энбесе.</ModOp>
     </Group>
   <!-- Enchanted Garden in Enbesa -->
     <Group>
@@ -49,8 +49,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
         Content="/TextExport/Texts/Text[GUID='22411']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Создаёт плодородие для индигоферы, при нахождении в Энбесе.</ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Создаёт плодородие для кофе, при нахождении в Энбесе.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Создаёт плодородие для индигоферы, при нахождении в Энбесе.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Создаёт плодородие для кофе, при нахождении в Энбесе.</ModOp>
     </Group>
   <!-- Near East Garden in Enbesa -->
     <Group>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_russian.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_russian.xml
@@ -1,94 +1,87 @@
 <ModOps>
-
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000111</GUID>
-      <Text>Музей</Text>
-    </Text>
-  </ModOp>	
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000112</GUID>
-      <Text>Зоопарк</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000113</GUID>
-      <Text>Ботанический сад</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000114</GUID>
-      <Text>Сад Амазонии</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000115</GUID>
-      <Text>Создаёт плодородие для гибискуса, при нахождении в Энбесе.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000116</GUID>
-      <Text>Сады Анд</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000117</GUID>
-      <Text>Создаёт плодородие для табака, при нахождении в Энбесе.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000118</GUID>
-      <Text>Зачарованный сад</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000119</GUID>
-      <Text>Создаёт плодородие для кофе, при нахождении в Энбесе.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000120</GUID>
-      <Text>Сад Ближнего Востока</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000121</GUID>
-      <Text>Создаёт плодородие для специй, при нахождении в Энбесе.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000122</GUID>
-      <Text>Субальпийский Сад</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000123</GUID>
-      <Text>Создаёт условия для распространения пчёл, при нахождении в Энбесе.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000124</GUID>
-      <Text>Порыв Энбесанского Плато</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000125</GUID>
-      <Text>Новые методы повышения урожайности.</Text>
-    </Text>
-  </ModOp>
-
+  <!-- Amazonas Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000115</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000115']/Text"
+        Content="/TextExport/Texts/Text[GUID='22404']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000115']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000115']/Text"
+        Content="/TextExport/Texts/Text[GUID='22409']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22404' or GUID='22409']/Text">&#xD;&#xA;&#xD;&#xA;Создаёт плодородие для гибискуса, при нахождении в Энбесе.</ModOp>
+    </Group>
+  <!-- Anden Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000117</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
+        Content="/TextExport/Texts/Text[GUID='22405']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
+        Content="/TextExport/Texts/Text[GUID='22410']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text">&#xD;&#xA;&#xD;&#xA;Создаёт плодородие для табака, при нахождении в Энбесе.</ModOp>
+    </Group>
+  <!-- Enchanted Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000119</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
+        Content="/TextExport/Texts/Text[GUID='22406']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
+        Content="/TextExport/Texts/Text[GUID='22411']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text">&#xD;&#xA;&#xD;&#xA;Создаёт плодородие для кофе, при нахождении в Энбесе.</ModOp>
+    </Group>
+  <!-- Near East Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000121</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000121']/Text"
+        Content="/TextExport/Texts/Text[GUID='22407']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000121']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000121']/Text"
+        Content="/TextExport/Texts/Text[GUID='22412']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22407' or GUID='22412']/Text">&#xD;&#xA;&#xD;&#xA;Cоздаёт плодородие для специй, при нахождении в Энбесе.</ModOp>
+    </Group>
+  <!-- Subalpine Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000123</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text"
+        Content="/TextExport/Texts/Text[GUID='22403']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text"
+        Content="/TextExport/Texts/Text[GUID='22408']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22403' or GUID='22408']/Text">&#xD;&#xA;&#xD;&#xA;Создаёт условия для распространения пчёл, при нахождении в Энбесе.</ModOp>
+    </Group>
 </ModOps>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_russian.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_russian.xml
@@ -31,7 +31,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
         Content="/TextExport/Texts/Text[GUID='22410']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text">&#xD;&#xA;&#xD;&#xA;Создаёт плодородие для табака, при нахождении в Энбесе.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Создаёт плодородие для тефа, при нахождении в Энбесе.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Создаёт плодородие для табака, при нахождении в Энбесе.</ModOp>
     </Group>
   <!-- Enchanted Garden in Enbesa -->
     <Group>
@@ -48,7 +49,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
         Content="/TextExport/Texts/Text[GUID='22411']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text">&#xD;&#xA;&#xD;&#xA;Создаёт плодородие для кофе, при нахождении в Энбесе.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Создаёт плодородие для индигоферы, при нахождении в Энбесе.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Создаёт плодородие для кофе, при нахождении в Энбесе.</ModOp>
     </Group>
   <!-- Near East Garden in Enbesa -->
     <Group>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_spanish.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_spanish.xml
@@ -1,94 +1,87 @@
 <ModOps>
-
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000111</GUID>
-      <Text>Museum</Text>
-    </Text>
-  </ModOp>	
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000112</GUID>
-      <Text>Zoo</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000113</GUID>
-      <Text>Botanical Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000114</GUID>
-      <Text>Amazonas Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000115</GUID>
-      <Text>Activates hibiscus fertility if built in Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000116</GUID>
-      <Text>Anden Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000117</GUID>
-      <Text>Activates tobacco fertility if built in Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000118</GUID>
-      <Text>Enchanted Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000119</GUID>
-      <Text>Activates coffee fertility if built in Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000120</GUID>
-      <Text>Near East Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000121</GUID>
-      <Text>Activates spices fertility if built in Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000122</GUID>
-      <Text>Subalpin Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000123</GUID>
-      <Text>Activates bee abundance if built in Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000124</GUID>
-      <Text>Inspiration of the Enbesan Plateau</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000125</GUID>
-      <Text>Bountiful Branches Crafting Techniques</Text>
-    </Text>
-  </ModOp>
-
+  <!-- Amazonas Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000115</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000115']/Text"
+        Content="/TextExport/Texts/Text[GUID='22404']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000115']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000115']/Text"
+        Content="/TextExport/Texts/Text[GUID='22409']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22404' or GUID='22409']/Text">&#xD;&#xA;&#xD;&#xA;Activates hibiscus fertility if built in Enbesa.</ModOp>
+    </Group>
+  <!-- Anden Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000117</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
+        Content="/TextExport/Texts/Text[GUID='22405']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
+        Content="/TextExport/Texts/Text[GUID='22410']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text">&#xD;&#xA;&#xD;&#xA;Activates tobacco fertility if built in Enbesa.</ModOp>
+    </Group>
+  <!-- Enchanted Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000119</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
+        Content="/TextExport/Texts/Text[GUID='22406']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
+        Content="/TextExport/Texts/Text[GUID='22411']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text">&#xD;&#xA;&#xD;&#xA;Activates coffee fertility if built in Enbesa.</ModOp>
+    </Group>
+  <!-- Near East Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000121</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000121']/Text"
+        Content="/TextExport/Texts/Text[GUID='22407']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000121']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000121']/Text"
+        Content="/TextExport/Texts/Text[GUID='22412']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22407' or GUID='22412']/Text">&#xD;&#xA;&#xD;&#xA;Activates spices fertility if built in Enbesa.</ModOp>
+    </Group>
+  <!-- Subalpine Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000123</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text"
+        Content="/TextExport/Texts/Text[GUID='22403']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text"
+        Content="/TextExport/Texts/Text[GUID='22408']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22403' or GUID='22408']/Text">&#xD;&#xA;&#xD;&#xA;Activates bee abundance if built in Enbesa.</ModOp>
+    </Group>
 </ModOps>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_spanish.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_spanish.xml
@@ -31,8 +31,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
         Content="/TextExport/Texts/Text[GUID='22410']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates teff fertility if built in Enbesa.</ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates tobacco fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Activates teff fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Activates tobacco fertility if built in Enbesa.</ModOp>
     </Group>
   <!-- Enchanted Garden in Enbesa -->
     <Group>
@@ -49,8 +49,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
         Content="/TextExport/Texts/Text[GUID='22411']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates indigo fertility if built in Enbesa.</ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates coffee fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Activates indigo fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Activates coffee fertility if built in Enbesa.</ModOp>
     </Group>
   <!-- Near East Garden in Enbesa -->
     <Group>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_spanish.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_spanish.xml
@@ -31,7 +31,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
         Content="/TextExport/Texts/Text[GUID='22410']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text">&#xD;&#xA;&#xD;&#xA;Activates tobacco fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates teff fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates tobacco fertility if built in Enbesa.</ModOp>
     </Group>
   <!-- Enchanted Garden in Enbesa -->
     <Group>
@@ -48,7 +49,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
         Content="/TextExport/Texts/Text[GUID='22411']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text">&#xD;&#xA;&#xD;&#xA;Activates coffee fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates indigo fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates coffee fertility if built in Enbesa.</ModOp>
     </Group>
   <!-- Near East Garden in Enbesa -->
     <Group>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_taiwanese.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_taiwanese.xml
@@ -1,94 +1,87 @@
 <ModOps>
-
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000111</GUID>
-      <Text>Museum</Text>
-    </Text>
-  </ModOp>	
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000112</GUID>
-      <Text>Zoo</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000113</GUID>
-      <Text>Botanical Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000114</GUID>
-      <Text>Amazonas Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000115</GUID>
-      <Text>Activates hibiscus fertility if built in Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000116</GUID>
-      <Text>Anden Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000117</GUID>
-      <Text>Activates tobacco fertility if built in Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000118</GUID>
-      <Text>Enchanted Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000119</GUID>
-      <Text>Activates coffee fertility if built in Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000120</GUID>
-      <Text>Near East Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000121</GUID>
-      <Text>Activates spices fertility if built in Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000122</GUID>
-      <Text>Subalpin Garden</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000123</GUID>
-      <Text>Activates bee abundance if built in Enbesa.</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000124</GUID>
-      <Text>Inspiration of the Enbesan Plateau</Text>
-    </Text>
-  </ModOp>
-  <ModOp Type="add" Path="/TextExport/Texts">
-    <Text>
-      <GUID>1999000125</GUID>
-      <Text>Bountiful Branches Crafting Techniques</Text>
-    </Text>
-  </ModOp>
-
+  <!-- Amazonas Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000115</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000115']/Text"
+        Content="/TextExport/Texts/Text[GUID='22404']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000115']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000115']/Text"
+        Content="/TextExport/Texts/Text[GUID='22409']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22404' or GUID='22409']/Text">&#xD;&#xA;&#xD;&#xA;Activates hibiscus fertility if built in Enbesa.</ModOp>
+    </Group>
+  <!-- Anden Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000117</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
+        Content="/TextExport/Texts/Text[GUID='22405']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
+        Content="/TextExport/Texts/Text[GUID='22410']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text">&#xD;&#xA;&#xD;&#xA;Activates tobacco fertility if built in Enbesa.</ModOp>
+    </Group>
+  <!-- Enchanted Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000119</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
+        Content="/TextExport/Texts/Text[GUID='22406']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
+        Content="/TextExport/Texts/Text[GUID='22411']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text">&#xD;&#xA;&#xD;&#xA;Activates coffee fertility if built in Enbesa.</ModOp>
+    </Group>
+  <!-- Near East Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000121</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000121']/Text"
+        Content="/TextExport/Texts/Text[GUID='22407']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000121']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000121']/Text"
+        Content="/TextExport/Texts/Text[GUID='22412']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22407' or GUID='22412']/Text">&#xD;&#xA;&#xD;&#xA;Activates spices fertility if built in Enbesa.</ModOp>
+    </Group>
+  <!-- Subalpine Garden in Enbesa -->
+    <Group>
+      <ModOp Type="add" Path="/TextExport/Texts">
+        <Text>
+          <GUID>1999000123</GUID>
+          <Text></Text>
+        </Text>
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text"
+        Content="/TextExport/Texts/Text[GUID='22403']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text">&#xD;&#xA;&#xD;&#xA;</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000123']/Text"
+        Content="/TextExport/Texts/Text[GUID='22408']/Text/text()">
+      </ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22403' or GUID='22408']/Text">&#xD;&#xA;&#xD;&#xA;Activates bee abundance if built in Enbesa.</ModOp>
+    </Group>
 </ModOps>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_taiwanese.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_taiwanese.xml
@@ -31,8 +31,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
         Content="/TextExport/Texts/Text[GUID='22410']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates teff fertility if built in Enbesa.</ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates tobacco fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Activates teff fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Activates tobacco fertility if built in Enbesa.</ModOp>
     </Group>
   <!-- Enchanted Garden in Enbesa -->
     <Group>
@@ -49,8 +49,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
         Content="/TextExport/Texts/Text[GUID='22411']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates indigo fertility if built in Enbesa.</ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates coffee fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Activates indigo fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa_modio">&#xD;&#xA;&#xD;&#xA;Activates coffee fertility if built in Enbesa.</ModOp>
     </Group>
   <!-- Near East Garden in Enbesa -->
     <Group>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_taiwanese.xml
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/data/config/gui/texts_taiwanese.xml
@@ -31,7 +31,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000117']/Text"
         Content="/TextExport/Texts/Text[GUID='22410']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text">&#xD;&#xA;&#xD;&#xA;Activates tobacco fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates teff fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22405' or GUID='22410']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates tobacco fertility if built in Enbesa.</ModOp>
     </Group>
   <!-- Enchanted Garden in Enbesa -->
     <Group>
@@ -48,7 +49,8 @@
       <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='1999000119']/Text"
         Content="/TextExport/Texts/Text[GUID='22411']/Text/text()">
       </ModOp>
-      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text">&#xD;&#xA;&#xD;&#xA;Activates coffee fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="!#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates indigo fertility if built in Enbesa.</ModOp>
+      <ModOp Type="add" Path="/TextExport/Texts/Text[GUID='22406' or GUID='22411']/Text" Condition="#Taludas_CoffeeTobaccoEnbesa">&#xD;&#xA;&#xD;&#xA;Activates coffee fertility if built in Enbesa.</ModOp>
     </Group>
   <!-- Near East Garden in Enbesa -->
     <Group>

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/modinfo.json
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/modinfo.json
@@ -6,11 +6,12 @@
   ],
   "LoadAfterIds": [
     "Fam_EnbesanFlora",
+    "shared-pools-and-definitions",
     "Spice_CulturalModuleLimits",
     "Spice_CulturalRadius",
     "Spice_BotanicalOrnaments",
     "Spice_WorldFairOrnaments",
-    "Taludas_CoffeeTobaccoEnbesa"
+    "Taludas_CoffeeTobaccoEnbesa_modio"
   ],
   "Category": {
     "Chinese": "Gameplay",

--- a/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/modinfo.json
+++ b/[Gameplay] Museum, Zoo and Botanical Garden in Enbesa (Taludas)/modinfo.json
@@ -9,7 +9,8 @@
     "Spice_CulturalModuleLimits",
     "Spice_CulturalRadius",
     "Spice_BotanicalOrnaments",
-    "Spice_WorldFairOrnaments"
+    "Spice_WorldFairOrnaments",
+    "Taludas_CoffeeTobaccoEnbesa"
   ],
   "Category": {
     "Chinese": "Gameplay",


### PR DESCRIPTION
- Zoo, Museum, Botanical Garden are now in the Culture section.
- Assets with identical names to vanilla or other mods have been switched to text override.
- The fluff texts have been changed so that the changes of the other two regions are always displayed.